### PR TITLE
Document nunjucks slim

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ nunjucks.env.addFilter( 'subview', function( templateName ) {
 } );
 ```
 
+### Using slim version of nunjucks
+
+Because all templates are precompiled, [nunjucks recommends](http://mozilla.github.io/nunjucks/api.html#recommended-setups)
+to use slim version that doesn't include compiler code.
+
+To do this, you should point nunjucks to a different location in your `package.json` browser config:
+
+```
+"browser": {
+  "nunjucks": "nunjucks/browser/nunjucks-slim"
+}
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
By default, nunjucksify requires nunjucks in browser, regular nunjucks.js is huge and [may be replaced with a slim version](http://mozilla.github.io/nunjucks/api.html#setup-2-always-precompile), because templates are already precompiled. To do so, one may set the following `browser` option in package.json:

```
"browser": {
    "nunjucks": "nunjucks/browser/nunjucks-slim"
}
```
