### PR TITLE
Adds nunjucksify.extensions to configure template file extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ console.log( tmpl.render( { menu : 'chorizo' } ) ); // outputs '<div>chorizo</di
 
 But wait, there's more.
 
-Nunjucksify overrides `evn.getTemplate()` within precompiled code so that the [node `require.resolve()` algorthim](http://nodejs.org/docs/v0.4.8/api/all.html#all_Together...) is used to resolve references in  `{% includes %}` and `{% extends %}` tags. As a result you can reference templates using relative paths:
+Nunjucksify overrides `env.getTemplate()` within precompiled code so that the [node `require.resolve()` algorthim](http://nodejs.org/docs/v0.4.8/api/all.html#all_Together...) is used to resolve references in  `{% includes %}` and `{% extends %}` tags. As a result you can reference templates using relative paths:
 
 ```jinja
 {% extends "./morcilla.nunj" %}
@@ -56,7 +56,7 @@ Declare nunjucksify as transform in `package.json` by adding `nunjucksify` to th
 
 ### Caring for the environment
 
-If you want your templates to use a particular nunjucks [Environment object](http://jlongster.github.io/nunjucks/api.html#environment), attach the environment object to `nunjucks.evn`. For example, the following makes a `subview` filter available to all your templates for use with [backbone.subviews](https://github.com/rotundasoftware/backbone.subviews#template-helpers). (If `nunjucks.env` is undefined, a new environment is created for each template.)
+If you want your templates to use a particular nunjucks [Environment object](http://jlongster.github.io/nunjucks/api.html#environment), attach the environment object to `nunjucks.env`. For example, the following makes a `subview` filter available to all your templates for use with [backbone.subviews](https://github.com/rotundasoftware/backbone.subviews#template-helpers). (If `nunjucks.env` is undefined, a new environment is created for each template.)
 
 ```javascript
 var nunjucks = require( 'nunjucks' );

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ nunjucks.env.addFilter( 'subview', function( templateName ) {
 If you want your templates to use a different extension, you can do so like this (default extension is `.nunj`):
 
 ```javascript
-bundle.transform(nunjucksify, {extensions: ['.html']});
+bundle.transform(nunjucksify, {extension: '.html'}); # For multiple extensions you can use extension: ['.html', '.nunj']
 ```
 
 ### Using slim version of nunjucks

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ cd path/to/my-package
 $ npm install nunjucksify --save
 ```
 
-Declare nunucksify as transform in `package.json` by adding `nunjucksify` to the array in the `browserify.transform` property. Cook 10-15 until crispy.
+Declare nunjucksify as transform in `package.json` by adding `nunjucksify` to the array in the `browserify.transform` property. Cook 10-15 until crispy.
 
 ### Caring for the environment
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ nunjucks.env.addFilter( 'subview', function( templateName ) {
 } );
 ```
 
+### Using a custom file extension
+
+If you want your templates to use a different extension, you can do so like this (default extension is `.nunj`):
+
+```javascript
+bundle.transform(nunjucksify, {extensions: ['.html']});
+```
+
 ### Using slim version of nunjucks
 
 Because all templates are precompiled, [nunjucks recommends](http://mozilla.github.io/nunjucks/api.html#recommended-setups)

--- a/index.js
+++ b/index.js
@@ -2,12 +2,13 @@ var through = require( "through" );
 var nunjucks = require( "nunjucks" );
 var path = require( "path" );
 
-nunjucksify = function( file, opts ) {
+module.exports = function( file, opts ) {
 	opts = opts || {};
 	var env = opts.env || new nunjucks.Environment();
+	var extensions = opts.extensions || ['.nunj'];
 
 	var data = "";
-	if( file !== undefined && nunjucksify.extensions.indexOf( path.extname( file ) ) === -1 )
+	if( file !== undefined && extensions.indexOf( path.extname( file ) ) === -1 )
 		return through();
 	else
 		return through( write, end );
@@ -76,6 +77,3 @@ nunjucksify = function( file, opts ) {
 	}
 };
 
-nunjucksify.extensions = ['.nunj']
-
-module.exports = nunjucksify

--- a/index.js
+++ b/index.js
@@ -5,10 +5,12 @@ var path = require( "path" );
 module.exports = function( file, opts ) {
 	opts = opts || {};
 	var env = opts.env || new nunjucks.Environment();
-	var extensions = opts.extensions || ['.nunj'];
+	var extension = opts.extension || ['.nunj'];
+
+	if ( !(extension instanceof Array) ) extension = [extension];
 
 	var data = "";
-	if( file !== undefined && extensions.indexOf( path.extname( file ) ) === -1 )
+	if( file !== undefined && extension.indexOf( path.extname( file ) ) === -1 )
 		return through();
 	else
 		return through( write, end );

--- a/index.js
+++ b/index.js
@@ -2,12 +2,12 @@ var through = require( "through" );
 var nunjucks = require( "nunjucks" );
 var path = require( "path" );
 
-module.exports = function( file, opts ) {
+nunjucksify = function( file, opts ) {
 	opts = opts || {};
 	var env = opts.env || new nunjucks.Environment();
 
 	var data = "";
-	if( file !== undefined && path.extname( file ) !== ".nunj" )
+	if( file !== undefined && nunjucksify.extensions.indexOf( path.extname( file ) ) === -1 )
 		return through();
 	else
 		return through( write, end );
@@ -75,3 +75,7 @@ module.exports = function( file, opts ) {
 		this.queue( null );
 	}
 };
+
+nunjucksify.extensions = ['.nunj']
+
+module.exports = nunjucksify

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "nunjucks": "~1.0.1",
+    "nunjucks": "~1.1.0",
     "through": "~2.3.4"
   },
   "devDependencies": {

--- a/test/test-file-extension-config/bundle.js
+++ b/test/test-file-extension-config/bundle.js
@@ -1,2 +1,3 @@
 var template = require( './template.html' );
-document.body.innerHTML = template.render();
+var context = require( './context.json' );
+document.body.innerHTML = template.render( context );

--- a/test/test-file-extension-config/bundle.js
+++ b/test/test-file-extension-config/bundle.js
@@ -1,0 +1,2 @@
+var template = require( './template.html' );
+document.body.innerHTML = template.render();

--- a/test/test-file-extension-config/context.json
+++ b/test/test-file-extension-config/context.json
@@ -1,0 +1,3 @@
+{
+  "firstName": "Hello, world"
+}

--- a/test/test-file-extension-config/template.html
+++ b/test/test-file-extension-config/template.html
@@ -1,0 +1,1 @@
+Using custom extension

--- a/test/test-file-extension-config/template.html
+++ b/test/test-file-extension-config/template.html
@@ -1,1 +1,1 @@
-Using custom extension
+<h1>{{ firstName }}</h1>

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,6 @@ specify( 'Renders the same in node and in dom', function ( done ) {
   compareWithNunjucksRender( 'compare-with-nunjucks-render', done );
 });
 
-
 specify( 'Correctly extends block', function ( done ) {
   compareWithNunjucksRender( 'test-extends', done );
 });
@@ -21,6 +20,24 @@ specify( 'Correctly compiles recursive dependencies', function ( done ) {
   compareWithNunjucksRender( 'resolve-recursive-dependencies', done );
 });
 
+specify( 'Uses custom file extension configuration', function ( done ) {
+  var previousExtensions = nunjucksify.extensions;
+  nunjucksify.extensions = ['.html'];
+  compileBundle('test-file-extension-config', function ( err, bundleSource ) {
+    nunjucksify.extensions = previousExtensions;
+    jsdom.env( {
+      html : '<html><body></body></html>',
+      src : [ bundleSource ],
+      done : function ( errors, window ) {
+        if ( errors ) {
+          return done( errors[0].data.error );
+        }
+        assert.equal( window.document.body.innerHTML, 'Using custom extension' );
+        done();
+      }
+    } );
+  });
+});
 
 specify( 'Prevent duplicate require calls for the same template', function ( done ) {
   compileBundle('prevent-duplicate-require-calls', function ( err, bundleSource ) {

--- a/test/test.js
+++ b/test/test.js
@@ -25,7 +25,7 @@ specify( 'Uses custom file extension configuration', function ( done ) {
   nunjucksify.extensions = ['.html'];
   compileBundle('test-file-extension-config', function ( err, bundleSource ) {
     nunjucksify.extensions = previousExtensions;
-    jsdom.env( {
+    jsdom.env({
       html : '<html><body></body></html>',
       src : [ bundleSource ],
       done : function ( errors, window ) {
@@ -35,7 +35,9 @@ specify( 'Uses custom file extension configuration', function ( done ) {
         assert.equal( window.document.body.innerHTML, 'Using custom extension' );
         done();
       }
-    } );
+    });
+  },{
+    extensions: ['.html']
   });
 });
 
@@ -75,11 +77,11 @@ function compareWithNunjucksRender( testName, done ) {
 }
 
 
-function compileBundle( testName, done ) {
+function compileBundle( testName, done, opts ) {
   var data = '';
   process.chdir( resolveTestPath( testName ) );
   return browserify()
-    .transform( nunjucksify )
+    .transform( nunjucksify, opts || {} )
     .add(resolveTestPath( testName, 'bundle.js' ) )
     .bundle()
     .pipe(

--- a/test/test.js
+++ b/test/test.js
@@ -20,24 +20,21 @@ specify( 'Correctly compiles recursive dependencies', function ( done ) {
   compareWithNunjucksRender( 'resolve-recursive-dependencies', done );
 });
 
-specify( 'Uses custom file extension configuration', function ( done ) {
-  var previousExtensions = nunjucksify.extensions;
-  nunjucksify.extensions = ['.html'];
-  compileBundle('test-file-extension-config', function ( err, bundleSource ) {
-    nunjucksify.extensions = previousExtensions;
-    jsdom.env({
-      html : '<html><body></body></html>',
-      src : [ bundleSource ],
-      done : function ( errors, window ) {
-        if ( errors ) {
-          return done( errors[0].data.error );
-        }
-        assert.equal( window.document.body.innerHTML, 'Using custom extension' );
-        done();
-      }
-    });
-  },{
-    extensions: ['.html']
+specify( 'Accepts custom file extension as string', function ( done ) {
+  compareWithNunjucksRender( 'test-file-extension-config', done, {
+    templateName: 'template.html',
+    nunjucksify: {
+      extension: '.html'
+    }
+  });
+});
+
+specify( 'Accepts custom file extension as array', function ( done ) {
+  compareWithNunjucksRender( 'test-file-extension-config', done, {
+    templateName: 'template.html',
+    nunjucksify: {
+      extension: ['.html']
+    }
   });
 });
 
@@ -52,7 +49,7 @@ specify( 'Prevent duplicate require calls for the same template', function ( don
 });
 
 
-function compareWithNunjucksRender( testName, done ) {
+function compareWithNunjucksRender( testName, done, opts ) {
   compileBundle( testName, function ( err, bundleSource ) {
     jsdom.env( {
       html : '<html><body></body></html>',
@@ -63,7 +60,8 @@ function compareWithNunjucksRender( testName, done ) {
         }
         var context = require( resolveTestPath( testName, 'context.json' ) );
         // Render from string to overcome cache
-        var template = fs.readFileSync( resolveTestPath( testName, 'template.nunj' ) ).toString( 'utf8' );
+        var templateName = (opts && opts.templateName) || 'template.nunj';
+        var template = fs.readFileSync( resolveTestPath( testName, templateName ) ).toString( 'utf8' );
         nunjucks.renderString( template, context, function ( err, desiredOutput ) {
           if ( err ) {
             return done( err );
@@ -73,7 +71,7 @@ function compareWithNunjucksRender( testName, done ) {
         } );
       }
     } );
-  } );
+  }, opts && opts.nunjucksify );
 }
 
 


### PR DESCRIPTION
I personally dislike the `.nunj` extension and prefer to simply use `.html` for the template files. When using browserify's JS API (for example in a Gulp task), you can now configure the extension with:
```nunjucksify.extensions = ['.html']```

Added test, but no docs, since it was not clear where to add it, and not sure how you would configure this in another setup other than Gulp.

Salute!