### PR TITLE
Move runtime shim to dedicated file

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,40 +46,7 @@ module.exports = function( file, opts ) {
 		}
 
 		compiledTemplate += 'var obj = (function () {' + nunjucksCompiledStr + '})();\n';
-		compiledTemplate += 'var oldRoot = obj.root;\n';
-		compiledTemplate += 'obj.root = function( env, context, frame, runtime, cb ) {\n';
-		compiledTemplate += '	var oldGetTemplate = env.getTemplate;\n';
-		compiledTemplate += '	env.getTemplate = function( name, ec, parentName, cb ) {\n';
-		compiledTemplate += '		if( typeof ec === "function" ) {\n';
-		compiledTemplate += '			cb = ec;\n';
-		compiledTemplate += '			ec = false;\n';
-		compiledTemplate += '		}\n';
-
-		compiledTemplate += '		var _require = function(name) {\n';
-		compiledTemplate += '			try {\n';
-		compiledTemplate += '				return require(name);\n';
-		compiledTemplate += '			} catch (e) {\n';
-		compiledTemplate += '				if ( frame.get( "_require" ) ) return frame.get( "_require" )( name )\n';
-		compiledTemplate += '			}\n';
-		compiledTemplate += '		};\n';
-		compiledTemplate += '		var tmpl = _require( name );\n';
-		compiledTemplate += '		frame.set( "_require", _require );\n';
-		compiledTemplate += '		if( ec ) tmpl.compile();\n';
-		compiledTemplate += '		cb( null, tmpl );\n';
-		compiledTemplate += '	};';
-
-		compiledTemplate += '	oldRoot( env, context, frame, runtime, function( err, res ) {\n';
-		compiledTemplate += '		env.getTemplate = oldGetTemplate;\n';
-		compiledTemplate += '		cb( err, res );\n';
-		compiledTemplate += '	} );\n';
-		compiledTemplate += '};\n';
-
-		compiledTemplate += 'var src = {\n';
-		compiledTemplate += '	obj: obj,\n';
-		compiledTemplate += '	type: "code"\n';
-		compiledTemplate += '};\n';
-
-		compiledTemplate += 'module.exports = new nunjucks.Template( src, env );\n';
+		compiledTemplate += 'module.exports = require( "nunjucksify/runtime-shim" )(nunjucks, env, obj, require);\n';
 
 		this.queue( compiledTemplate );
 		this.queue( null );

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.2.2",
   "description": "nunjucks transform for browserify",
   "main": "index.js",
+  "browser": {
+    "nunjucksify/runtime-shim": "./runtime-shim.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/rotundasoftware/nunjucksify.git"

--- a/runtime-shim.js
+++ b/runtime-shim.js
@@ -1,0 +1,39 @@
+module.exports = function ( nunjucks, env, obj, __require ) {
+
+	var oldRoot = obj.root;
+
+	obj.root = function( env, context, frame, runtime, cb ) {
+		var oldGetTemplate = env.getTemplate;
+		env.getTemplate = function( name, ec, parentName, cb ) {
+			if( typeof ec === "function" ) {
+				cb = ec;
+				ec = false;
+			}
+
+			var _require = function(name) {
+				try {
+					return __require(name);
+				} catch (e) {
+					if ( frame.get( "_require" ) ) return frame.get( "_require" )( name );
+				}
+			};
+			var tmpl = _require( name );
+			frame.set( "_require", _require );
+			if( ec ) tmpl.compile();
+			cb( null, tmpl );
+		};
+
+		oldRoot( env, context, frame, runtime, function( err, res ) {
+			env.getTemplate = oldGetTemplate;
+			cb( err, res );
+		} );
+	};
+
+	var src = {
+		obj: obj,
+		type: "code"
+	};
+
+	return new nunjucks.Template( src, env );
+
+};


### PR DESCRIPTION
It takes the same approach as [nunjucks-loader](https://github.com/at0g/nunjucks-loader) for Webpack - separates runtime shim to dedicated file.

Benefits:

1. Easier editing.
1. Dedicated module which can be extracted to common bundle and be required and referenced just once, making required files really small if you have large set of templates.

The tests aren’t passing, but they don’t pass even without these changes, do you know what can be the problem?