### PR TITLE
Bump nunjucks dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
-var through = require( "through" );
-var nunjucks = require( "nunjucks" );
-var path = require( "path" );
+var through = require( 'through' );
+var nunjucks = require( 'nunjucks' );
+var path = require( 'path' );
 
 module.exports = function( file, opts ) {
 	opts = opts || {};
 	var env = opts.env || nunjucks.env || new nunjucks.Environment();
-	var extension = opts.extension || ['.nunj'];
+	var extension = opts.extension || [ '.nunj', '.njk' ];
+	var rootDir = opts.rootDir;
 
 	if ( !(extension instanceof Array) ) extension = [extension];
 
@@ -21,32 +22,19 @@ module.exports = function( file, opts ) {
 
 	function end() {
 		var compiledTemplate = '';
+		
+		compiledTemplate += 'var nunjucks = require( "nunjucks/browser/nunjucks-slim" );\n';
+		
+		var templateName = file;
+		if( opts.rootDir ) templateName = path.relative( opts.rootDir, templateName );
+		
+		precompiledTemplateString = nunjucks.precompileString( data, {
+            env : env,
+            name : templateName,
+            asFunction : true
+        } );
 
-		compiledTemplate += 'var nunjucks = require( "nunjucks" );\n';
-		compiledTemplate += 'var env = nunjucks.env || new nunjucks.Environment();\n';
-
-		var nunjucksCompiledStr;
-
-		try {
-			nunjucksCompiledStr = nunjucks.compiler.compile( data, env.asyncFilters, env.extensionsList );
-		} catch( err ) {
-			this.queue( null );
-			return this.emit( 'error', err );
-		}
-
-		var reg = /env\.getTemplate\(\"(.*?)\"/g;
-		var match;
-		var required = {};
-		while( match = reg.exec( nunjucksCompiledStr ) ) {
-			var templateRef = match[1];
-			if (!required[templateRef]) {
-				compiledTemplate += 'require( "' + templateRef + '" );\n';
-				required[templateRef] = true;
-			}
-		}
-
-		compiledTemplate += 'var obj = (function () {' + nunjucksCompiledStr + '})();\n';
-		compiledTemplate += 'module.exports = require( "nunjucksify/runtime-shim" )(nunjucks, env, obj, require);\n';
+		compiledTemplate += 'module.exports = ' + precompiledTemplateString + ';\n';
 
 		this.queue( compiledTemplate );
 		this.queue( null );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nunjucksify",
-  "version": "0.2.3",
+  "version": "1.0.0",
   "description": "nunjucks transform for browserify",
   "main": "index.js",
   "browser": {
@@ -26,7 +26,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "nunjucks": "~1.3.4",
+    "nunjucks": "https://github.com/mozilla/nunjucks.git#165cb528bc62c482afc91158b3d365e2b27188ac",
     "through": "~2.3.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "nunjucks": "https://github.com/mozilla/nunjucks.git#165cb528bc62c482afc91158b3d365e2b27188ac",
+    "nunjucks": "https://github.com/dgbeck/nunjucks.git#68a456b3d80a0961f4fab8bc79c5c8a4e304246a",
     "through": "~2.3.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "nunjucks": "https://github.com/dgbeck/nunjucks.git#68a456b3d80a0961f4fab8bc79c5c8a4e304246a",
+    "nunjucks": "^3.0.0",
     "through": "~2.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps to nunjucks 2.x. However, due to this issue, which basically breaks nunjucks 2.x in browserify / web pack environments:

https://github.com/rotundasoftware/nunjucksify/issues/13

and still has not been resolved in the latest release of nunjucks (2.4.3), this PR can not yet be merged.

after [this change](https://github.com/mozilla/nunjucks/pull/753) makes it way to released version of nunjucks we can move forward. My understanding is that this change will be made in nunjucks v3.0.0.